### PR TITLE
fix: update stdio server API for current MCP SDK

### DIFF
--- a/src/ashby/server.py
+++ b/src/ashby/server.py
@@ -424,7 +424,15 @@ async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[types.T
 
 async def run():
     """Run the MCP server."""
-    await mcp.server.stdio.run_async(server)
+    async with mcp.server.stdio.stdio_server() as (read_stream, write_stream):
+        await server.run(read_stream, write_stream, InitializationOptions(
+            server_name="ashby-mcp",
+            server_version="0.1.0",
+            capabilities=server.get_capabilities(
+                notification_options=NotificationOptions(),
+                experimental_capabilities={},
+            ),
+        ))
 
 if __name__ == "__main__":
-    asyncio.run(run()) 
+    asyncio.run(run())

--- a/src/ashby/server.py
+++ b/src/ashby/server.py
@@ -6,6 +6,7 @@
 # ]
 # ///
 import asyncio
+import base64
 import json
 from typing import Any, Optional
 import os
@@ -36,8 +37,9 @@ class AshbyClient:
             if not self.api_key:
                 raise ValueError("ASHBY_API_KEY environment variable not set")
             
+            encoded = base64.b64encode(f"{self.api_key}:".encode()).decode()
             self.headers = {
-                "Authorization": f"Basic {self.api_key}",
+                "Authorization": f"Basic {encoded}",
                 "Content-Type": "application/json"
             }
             return True
@@ -318,7 +320,7 @@ async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[types.T
                 method="POST",
                 data=arguments
             )
-            return [types.TextContent(text=f"Created candidate: {json.dumps(response, indent=2)}")]
+            return [types.TextContent(type="text", text=f"Created candidate: {json.dumps(response, indent=2)}")]
             
         elif name == "search_candidates":
             response = ashby_client._make_request(
@@ -326,7 +328,7 @@ async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[types.T
                 method="POST",
                 data=arguments
             )
-            return [types.TextContent(text=f"Search results: {json.dumps(response, indent=2)}")]
+            return [types.TextContent(type="text", text=f"Search results: {json.dumps(response, indent=2)}")]
             
         elif name == "list_candidates":
             response = ashby_client._make_request(
@@ -334,7 +336,7 @@ async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[types.T
                 method="POST",
                 data=arguments
             )
-            return [types.TextContent(text=f"Candidate list: {json.dumps(response, indent=2)}")]
+            return [types.TextContent(type="text", text=f"Candidate list: {json.dumps(response, indent=2)}")]
             
         elif name == "create_job":
             response = ashby_client._make_request(
@@ -342,7 +344,7 @@ async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[types.T
                 method="POST",
                 data=arguments
             )
-            return [types.TextContent(text=f"Created job: {json.dumps(response, indent=2)}")]
+            return [types.TextContent(type="text", text=f"Created job: {json.dumps(response, indent=2)}")]
             
         elif name == "search_jobs":
             response = ashby_client._make_request(
@@ -350,7 +352,7 @@ async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[types.T
                 method="POST",
                 data=arguments
             )
-            return [types.TextContent(text=f"Job search results: {json.dumps(response, indent=2)}")]
+            return [types.TextContent(type="text", text=f"Job search results: {json.dumps(response, indent=2)}")]
             
         elif name == "create_application":
             response = ashby_client._make_request(
@@ -358,7 +360,7 @@ async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[types.T
                 method="POST",
                 data=arguments
             )
-            return [types.TextContent(text=f"Created application: {json.dumps(response, indent=2)}")]
+            return [types.TextContent(type="text", text=f"Created application: {json.dumps(response, indent=2)}")]
             
         elif name == "list_applications":
             response = ashby_client._make_request(
@@ -366,7 +368,7 @@ async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[types.T
                 method="POST",
                 data=arguments
             )
-            return [types.TextContent(text=f"Application list: {json.dumps(response, indent=2)}")]
+            return [types.TextContent(type="text", text=f"Application list: {json.dumps(response, indent=2)}")]
             
         elif name == "create_interview":
             response = ashby_client._make_request(
@@ -374,7 +376,7 @@ async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[types.T
                 method="POST",
                 data=arguments
             )
-            return [types.TextContent(text=f"Created interview: {json.dumps(response, indent=2)}")]
+            return [types.TextContent(type="text", text=f"Created interview: {json.dumps(response, indent=2)}")]
             
         elif name == "list_interviews":
             response = ashby_client._make_request(
@@ -382,7 +384,7 @@ async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[types.T
                 method="POST",
                 data=arguments
             )
-            return [types.TextContent(text=f"Interview list: {json.dumps(response, indent=2)}")]
+            return [types.TextContent(type="text", text=f"Interview list: {json.dumps(response, indent=2)}")]
             
         elif name == "get_pipeline_metrics":
             response = ashby_client._make_request(
@@ -390,7 +392,7 @@ async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[types.T
                 method="POST",
                 data=arguments
             )
-            return [types.TextContent(text=f"Pipeline metrics: {json.dumps(response, indent=2)}")]
+            return [types.TextContent(type="text", text=f"Pipeline metrics: {json.dumps(response, indent=2)}")]
             
         elif name == "bulk_create_candidates":
             response = ashby_client._make_request(
@@ -398,7 +400,7 @@ async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[types.T
                 method="POST",
                 data=arguments
             )
-            return [types.TextContent(text=f"Bulk create results: {json.dumps(response, indent=2)}")]
+            return [types.TextContent(type="text", text=f"Bulk create results: {json.dumps(response, indent=2)}")]
             
         elif name == "bulk_update_applications":
             response = ashby_client._make_request(
@@ -406,7 +408,7 @@ async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[types.T
                 method="POST",
                 data=arguments
             )
-            return [types.TextContent(text=f"Bulk update results: {json.dumps(response, indent=2)}")]
+            return [types.TextContent(type="text", text=f"Bulk update results: {json.dumps(response, indent=2)}")]
             
         elif name == "bulk_schedule_interviews":
             response = ashby_client._make_request(
@@ -414,13 +416,13 @@ async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[types.T
                 method="POST",
                 data=arguments
             )
-            return [types.TextContent(text=f"Bulk schedule results: {json.dumps(response, indent=2)}")]
+            return [types.TextContent(type="text", text=f"Bulk schedule results: {json.dumps(response, indent=2)}")]
             
         else:
             raise ValueError(f"Unknown tool: {name}")
             
     except Exception as e:
-        return [types.TextContent(text=f"Error executing {name}: {str(e)}")]
+        return [types.TextContent(type="text", text=f"Error executing {name}: {str(e)}")]
 
 async def run():
     """Run the MCP server."""


### PR DESCRIPTION
Replace deprecated mcp.server.stdio.run_async() with stdio_server() context manager, which is the current API in the mcp package.

This is needed to get mcp-ashby to work with the latest version of Claude Code / Codex.